### PR TITLE
quote password for bitbucket curl request

### DIFF
--- a/fbox/fabfile/git.py
+++ b/fbox/fabfile/git.py
@@ -43,7 +43,7 @@ def init_bitbucket():
         return 1
 
     if username and password and organization and repository:
-        env.box_auth = '%s:%s' % (username, password)
+        env.box_auth = '%s:"%s"' % (username, password)
         env.box_repo = '%s/%s' % (organization, repository)
 
         with hide('running'):


### PR DESCRIPTION
when using secure passwords the pwd has to be quoted for the curl request to bitbucket, otherwise it can throw a simple syntax error
((if quotes are the real thing, i do not know...)